### PR TITLE
[IWW-10][IWW-14] Todo-user 왜래키 추가, entity 컬럼 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,12 +14,6 @@ import { RoutineModule } from './routine/routine.module';
 import { APP_FILTER } from '@nestjs/core';
 import { DoWithExceptionFilter } from './do-with-exception-filter/do-with-exception.filter';
 
-// timezone check
-const now = new Date();
-const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-console.log(timeZone); // 현재 타임존 출력
-console.log(new Date().toISOString());
-
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -65,3 +59,15 @@ export class AppModule implements NestModule {
     consumer.apply(DoWithMiddlewareMiddleware).forRoutes('');
   }
 }
+
+// timezone check
+const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+console.log(timeZone); // 현재 타임존 출력
+
+function getNow() {
+  const event = new Date();
+  event.setTime(event.getTime() - event.getTimezoneOffset() * 60 * 1000);
+  return event.toISOString();
+}
+
+console.log( getNow()); // 현재 타임존의 시간 출력

--- a/src/todo/dto/create-todo.dto.ts
+++ b/src/todo/dto/create-todo.dto.ts
@@ -13,8 +13,8 @@ export class CreateTodoDto {
   todo_done: boolean;
 
   // optional
-  todo_start: Date;
-  todo_end: Date;
+  todo_start: string;
+  todo_end: string;
   grp_id: number; // foreign key
   // path of image, nessary if grp_id is not null
   todo_img: string;

--- a/src/todo/dto/create-todo.dto.ts
+++ b/src/todo/dto/create-todo.dto.ts
@@ -8,7 +8,7 @@ export class CreateTodoDto {
   @IsNotEmpty()
   todo_name: string;
   todo_desc: string;
-  todo_label: number;
+  todo_label: string;
   todo_date: Date;
   todo_done: boolean;
 

--- a/src/todo/dto/create-todo.dto.ts
+++ b/src/todo/dto/create-todo.dto.ts
@@ -4,20 +4,19 @@ export class CreateTodoDto {
   @IsNotEmpty()
   user_id: number; // foreign key
 
+  // essential
   @IsNotEmpty()
   todo_name: string;
-
   todo_desc: string;
-
-  @IsNotEmpty()
+  todo_label: number;
+  todo_date: Date;
   todo_done: boolean;
 
+  // optional
   todo_start: Date;
-
   todo_end: Date;
-
   grp_id: number; // foreign key
-
   // path of image, nessary if grp_id is not null
   todo_img: string;
+
 }

--- a/src/todo/dto/update-todo.dto.ts
+++ b/src/todo/dto/update-todo.dto.ts
@@ -1,0 +1,33 @@
+import { IsNotEmpty } from 'class-validator';
+
+  /**
+   * 수정가능 목록
+   * 제목: todo_name
+   * 내용: todo_desc
+   * 라벨: todo_label
+   * 날짜: todo_date
+   * 완료여부: todo_done
+   * 
+   * 시작시간: todo_start
+   * 종료시간: todo_end
+   * 이미지 경로: todo_img
+   */
+
+export class UpdateTodoDto {
+  // todo_id, user_id, grp_id는 변경 불가
+
+  // essential
+  @IsNotEmpty()
+  todo_name: string;
+  todo_desc: string;
+  todo_label: number;
+  todo_date: Date;
+  todo_done: boolean;
+
+  // optional
+  todo_start: Date;
+  todo_end: Date;
+  // path of image, nessary if grp_id is not null
+  todo_img: string;
+
+}

--- a/src/todo/dto/update-todo.dto.ts
+++ b/src/todo/dto/update-todo.dto.ts
@@ -20,7 +20,7 @@ export class UpdateTodoDto {
   @IsNotEmpty()
   todo_name: string;
   todo_desc: string;
-  todo_label: number;
+  todo_label: string;
   todo_date: Date;
   todo_done: boolean;
 

--- a/src/todo/dto/update-todo.dto.ts
+++ b/src/todo/dto/update-todo.dto.ts
@@ -25,8 +25,8 @@ export class UpdateTodoDto {
   todo_done: boolean;
 
   // optional
-  todo_start: Date;
-  todo_end: Date;
+  todo_start: string;
+  todo_end: string;
   // path of image, nessary if grp_id is not null
   todo_img: string;
 

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
+import { UpdateTodoDto } from './dto/update-todo.dto';
 import { Todo } from './todo.entity';
 
 @Controller('todo')
@@ -39,9 +40,9 @@ export class TodoController {
   @Put('/:todo_id')
   update(
     @Param('todo_id', ParseIntPipe) todo_id: number,
-    @Body() createTodoDto: CreateTodoDto,
+    @Body() updateTodoDto: UpdateTodoDto,
   ): Promise<Todo> {
-    return this.todoService.update(todo_id, createTodoDto);
+    return this.todoService.update(todo_id, updateTodoDto);
   }
 
   @Delete('/:todo_id')
@@ -52,8 +53,8 @@ export class TodoController {
   @Patch('/:todo_id')
   editDone(
     @Param('todo_id', ParseIntPipe) todo_id: number,
-    @Body() createTodoDto: CreateTodoDto,
+    @Body() updateTodoDto: UpdateTodoDto,
   ): Promise<Todo> {
-    return this.todoService.editDone(todo_id, createTodoDto);
+    return this.todoService.editDone(todo_id, updateTodoDto);
   }
 }

--- a/src/todo/todo.entity.ts
+++ b/src/todo/todo.entity.ts
@@ -24,7 +24,7 @@ export class Todo {
   @Column({ nullable: false, default: 0 })
   todo_label: number;
 
-  @CreateDateColumn()
+  @CreateDateColumn() // default: now()
   todo_date: Date;
 
   @Column({ default: false })

--- a/src/todo/todo.entity.ts
+++ b/src/todo/todo.entity.ts
@@ -2,8 +2,10 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { User } from '../user/user.entities';
 
 @Entity()
 export class Todo {
@@ -37,7 +39,9 @@ export class Todo {
   @Column({ nullable: true })
   todo_img: string;
 
-  // TODO ManyToOne: user_id
+  @ManyToOne(type => User, user => user.todos)
+  user: User;
+  // NOTE todo데이터 보존을 위해 CASCADE 미설정
   // TODO ManyToOne: grp_id
   // TODO todo_image: path of image
 }

--- a/src/todo/todo.entity.ts
+++ b/src/todo/todo.entity.ts
@@ -21,8 +21,8 @@ export class Todo {
   @Column({ nullable: true })
   todo_desc: string;
 
-  @Column({ nullable: false, default: 0 })
-  todo_label: number;
+  @Column({ nullable: false, default: "etc" })
+  todo_label: string;
 
   @CreateDateColumn() // default: now()
   todo_date: Date;

--- a/src/todo/todo.entity.ts
+++ b/src/todo/todo.entity.ts
@@ -39,6 +39,9 @@ export class Todo {
   @Column({ nullable: true })
   todo_img: string;
 
+  @Column({ nullable: false, default: false })
+  todo_deleted: boolean;
+
   @ManyToOne(type => User, user => user.todos)
   user: User;
   // NOTE todo데이터 보존을 위해 CASCADE 미설정

--- a/src/todo/todo.entity.ts
+++ b/src/todo/todo.entity.ts
@@ -30,11 +30,11 @@ export class Todo {
   @Column({ default: false })
   todo_done: boolean;
 
-  @Column({ nullable: true })
-  todo_start: Date;
+  @Column({ nullable: true, default: "00:00" })
+  todo_start: string;
 
-  @Column({ nullable: true })
-  todo_end: Date;
+  @Column({ nullable: true, default: "00:00" })
+  todo_end: string;
 
   @Column({ nullable: true })
   grp_id: number; // foreign key

--- a/src/todo/todo.entity.ts
+++ b/src/todo/todo.entity.ts
@@ -42,6 +42,9 @@ export class Todo {
   @Column({ nullable: false, default: false })
   todo_deleted: boolean;
 
+  @Column({ nullable: false, default: 0 })
+  todo_label: number;
+
   @ManyToOne(type => User, user => user.todos)
   user: User;
   // NOTE todo데이터 보존을 위해 CASCADE 미설정

--- a/src/todo/todo.entity.ts
+++ b/src/todo/todo.entity.ts
@@ -21,6 +21,9 @@ export class Todo {
   @Column({ nullable: true })
   todo_desc: string;
 
+  @Column({ nullable: false, default: 0 })
+  todo_label: number;
+
   @CreateDateColumn()
   todo_date: Date;
 
@@ -41,9 +44,6 @@ export class Todo {
 
   @Column({ nullable: false, default: false })
   todo_deleted: boolean;
-
-  @Column({ nullable: false, default: 0 })
-  todo_label: number;
 
   @ManyToOne(type => User, user => user.todos)
   user: User;

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Todo } from './todo.entity';
 import { CreateTodoDto } from './dto/create-todo.dto';
+import { UpdateTodoDto } from './dto/update-todo.dto';
 
 @Injectable()
 export class TodoService {
@@ -13,20 +14,25 @@ export class TodoService {
 
   // READ
   async findAllByUser(user_id: number): Promise<Todo[]> {
-    return await this.todoRepository.findBy({ user_id });
+    return await this.todoRepository.findBy({ user_id, todo_deleted: false });
   }
 
   async findOne(todo_id: number): Promise<Todo> {
-    return await this.todoRepository.findOneBy({ todo_id });
+    return await this.todoRepository.findOneBy({ todo_id, todo_deleted: false });
   }
 
   // CREATE
   async create(createTodoDto: CreateTodoDto): Promise<Todo> {
     const todo = new Todo();
+    // todo_id, todo_deleted: default
     todo.user_id = createTodoDto.user_id;
+
     todo.todo_name = createTodoDto.todo_name;
     todo.todo_desc = createTodoDto.todo_desc;
+    todo.todo_label = createTodoDto.todo_label;
+    todo.todo_date = createTodoDto.todo_date;
     todo.todo_done = createTodoDto.todo_done;
+
     todo.todo_start = createTodoDto.todo_start;
     todo.todo_end = createTodoDto.todo_end;
     todo.grp_id = createTodoDto.grp_id;
@@ -36,30 +42,32 @@ export class TodoService {
   }
 
   // UPDATE
-  async update(todo_id: number, createTodoDto: CreateTodoDto): Promise<Todo> {
+  async update(todo_id: number, dto: UpdateTodoDto): Promise<Todo> {
     const todo = await this.todoRepository.findOneBy({ todo_id });
-    todo.user_id = createTodoDto.user_id;
-    todo.todo_name = createTodoDto.todo_name;
-    todo.todo_desc = createTodoDto.todo_desc;
-    todo.todo_done = createTodoDto.todo_done;
-    todo.todo_start = createTodoDto.todo_start;
-    todo.todo_end = createTodoDto.todo_end;
-    todo.grp_id = createTodoDto.grp_id;
-    todo.todo_img = createTodoDto.todo_img;
+    todo.todo_name = dto.todo_name;
+    todo.todo_desc = dto.todo_desc;
+    todo.todo_date = dto.todo_date;
+    todo.todo_done = dto.todo_done;
+
+    todo.todo_start = dto.todo_start;
+    todo.todo_end = dto.todo_end;
+    todo.todo_img = dto.todo_img;
+    todo.todo_label = dto.todo_label;
 
     return await this.todoRepository.save(todo);
   }
 
   // DELETE
   async delete(todo_id: number): Promise<void> {
-    await await this.todoRepository.delete({ todo_id });
+    const todo = await this.todoRepository.findOneBy({ todo_id });
+    todo.todo_deleted = true;
   }
 
   // todo 완료상태 변경
-  async editDone(todo_id: number, createTodoDto: CreateTodoDto): Promise<Todo> {
+  async editDone(todo_id: number, dto: UpdateTodoDto): Promise<Todo> {
     const todo = await this.todoRepository.findOneBy({ todo_id });
-    todo.todo_done = createTodoDto.todo_done;
-
+    todo.todo_done = dto.todo_done;
+    
     return this.todoRepository.save(todo);
   }
 }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -44,15 +44,12 @@ export class TodoService {
   // UPDATE
   async update(todo_id: number, dto: UpdateTodoDto): Promise<Todo> {
     const todo = await this.todoRepository.findOneBy({ todo_id });
-    todo.todo_name = dto.todo_name;
-    todo.todo_desc = dto.todo_desc;
-    todo.todo_date = dto.todo_date;
-    todo.todo_done = dto.todo_done;
 
-    todo.todo_start = dto.todo_start;
-    todo.todo_end = dto.todo_end;
-    todo.todo_img = dto.todo_img;
-    todo.todo_label = dto.todo_label;
+    Object.keys(dto).forEach(key => {
+      if (dto[key] !== null && dto[key] !== undefined) {
+        todo[key] = dto[key];
+      }
+    });
 
     return await this.todoRepository.save(todo);
   }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -61,6 +61,7 @@ export class TodoService {
   async delete(todo_id: number): Promise<void> {
     const todo = await this.todoRepository.findOneBy({ todo_id });
     todo.todo_deleted = true;
+    await this.todoRepository.save(todo);
   }
 
   // todo 완료상태 변경

--- a/src/user/user.entities.ts
+++ b/src/user/user.entities.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Todo } from '../todo/todo.entity';
 
 @Entity()
 export class User {
@@ -29,4 +30,7 @@ export class User {
 
   @Column()
   lastLogin: Date;
+
+  @OneToMany(() => Todo, (todo) => todo.user)
+  todos: Todo[];
 }


### PR DESCRIPTION
### todo - user 왜래키 및 종속 추가
todo -> user: many to one
user -> todo: one to many

### entity 컬럼 추가
todo_label: number (DB에서 테이블 따로 생성하여 관리 
todo_deleted: boolean (삭제처리 여부)


### API 수정
CREATE
- POST /todo/:todo_id 
  - todo_label 을 설정하여 생성할 수 있다. 

READ
- GET /todo/:todo_id, /todo/user/:user_id
  - todo_deleted가 설정되지 않은 값만 가져온다.

UPDATE
- PUT /todo/:todo_id
  - todo_label을 수정할 수 있다.
  - todo_date를 수정할 수 있다.
- PATCH /todo/:todo_id
- todo_done을 수정할 수 있다. (완료 여부)

DELETE
- DELETE /todo/:todo_id
  - 이제 데이터를 실제로 삭제하지 않고 삭제되었다고 컬럼값만 변경한다.




