### PR TITLE
JWT 토큰 인증시 payload 유저 아이디가 undefined인 경우 예외처리

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -79,7 +79,6 @@ export class AuthService {
                                 .execute();
 
       const user_id = createUser.identifiers[0].user_id;
-      Logger.debug(`new user id ${user_id}`);
 
       // 2. 첫 로그인 업적 달성
       const loginAchi = await queryRunner.manager.findOneBy(

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -19,14 +19,20 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload) {
-    const { user_id } = payload;
+    const { userId, user_id } = payload;
+    const id = userId == undefined ? user_id : userId;
+    if(id == undefined) {
+        throw new UnauthorizedException();
+    }
+
     const user: User = await this.userRepository.findOneBy({
-      user_id: user_id,
+      user_id: id,
     });
+
     if (user == null) {
-      // User not found
       throw new UnauthorizedException();
     }
+    
     return user;
   }
 }

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -20,8 +20,9 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload) {
     const { userId, user_id } = payload;
-    const id = userId == undefined ? user_id : userId;
-    if(id == undefined) {
+    
+    const id = userId || user_id;
+    if(!id) {
         throw new UnauthorizedException();
     }
 

--- a/src/features/user/user.controller.ts
+++ b/src/features/user/user.controller.ts
@@ -43,6 +43,7 @@ export class UserController {
   async getUser(
     @Request() req,
   ): Promise<{ result }> {
+    
     return await this.usersService.getUserInfo(req.user);
   }
 

--- a/src/features/user/user.service.ts
+++ b/src/features/user/user.service.ts
@@ -24,9 +24,6 @@ export class UserService {
   async getUserInfo(user: User) {
     const {user_id} = user;
     const user_pet = await this.getUserMainPet(user_id);
-
-    Logger.debug(user);
-    Logger.debug(user_pet);
   
     const result = { user, user_pet };
     return { result };


### PR DESCRIPTION
* payload의 user_id 또는 userId 값 체크
* undefined인 경우 UnauthorizedException
* typeORM은 undefined된 값이 들어오는 경우 종종 첫번째 or 가장 최근 레코드를 반환한다고 합니다.

> 
> TypeORM의 findOneBy 메소드가 예상과 다르게 동작하는 것에 대한 문제를 짚고 넘어가야 할 것 같습니다. findOneBy 메소드는 특정 조건에 맞는 단일 엔티티를 찾는데 사용됩니다. 여기서 문제가 되는 부분은 userId가 undefined 일 때의 동작입니다.
> 
> findOneBy 메소드에 undefined 값을 넘기는 경우, TypeORM은 종종 이 조건을 무시하고 데이터베이스의 첫 번째 레코드를 반환할 수 있습니다. 이는 TypeORM의 동작 방식에 따른 것이며, 조건이 없는 것으로 간주되어 가장 최근에 추가된 레코드나 첫 번째 레코드를 반환하는 것일 수 있습니다.

