### PR TITLE
[데모 스크립트 초안][로컬 테스트 완료]

### DIFF
--- a/src/features/user/demo.ts
+++ b/src/features/user/demo.ts
@@ -153,7 +153,7 @@ export class Demo {
     }
 
     private toFormattedDate(val: Date) {
-        const year = val.getFullYear() % 100;
+        const year = val.getFullYear();
         const month = (val.getMonth() + 1).toString().padStart(2, '0');
         const date = val.getDate().toString().padStart(2, '0');
 

--- a/src/features/user/demo.ts
+++ b/src/features/user/demo.ts
@@ -1,0 +1,125 @@
+import { Injectable } from "@nestjs/common";
+import { Attendance } from "src/entities/attendance.entity";
+import { ItemInventory } from "src/entities/item-inventory.entity";
+import { Room } from "src/entities/room.entity";
+import { Todo } from "src/entities/todo.entity";
+import { User } from "src/entities/user.entities";
+import { UserAchi } from "src/entities/user_achi.entity";
+import { DataSource, Repository } from "typeorm";
+
+@Injectable()
+export class Demo {
+    constructor(
+        private readonly dataSource: DataSource,
+    ){}
+
+    async demo(userId:number) {
+        const userRepo: Repository<User>          = this.dataSource.getRepository(User);
+        const todoRepo: Repository<Todo>          = this.dataSource.getRepository(Todo);
+        const atteRepo: Repository<Attendance>    = this.dataSource.getRepository(Attendance);
+        const achiRepo: Repository<UserAchi>      = this.dataSource.getRepository(UserAchi);
+        const inveRepo: Repository<ItemInventory> = this.dataSource.getRepository(ItemInventory);
+        const roomRepo: Repository<Room>          = this.dataSource.getRepository(Room);
+
+        const achiId = 6;
+
+        // 1. 출결 모두 삭제, 로그인 업적 삭제
+        await atteRepo.delete({user_id: userId});
+        await achiRepo.delete({user_id: userId, achi_id: achiId});
+
+        
+        // 2. 오늘자 그룹 투두 삭제, 개인 투두 모두 false로 변경
+        await todoRepo.createQueryBuilder()
+            .delete()
+            .where(`
+                user_id  = :userId AND  \
+                grp_id IS NOT NULL AND  \
+                todo_date = DATE(now()) \
+            `, {userId})
+            .execute();
+
+        await todoRepo.createQueryBuilder()
+            .update()
+            .where(`
+                user_id   = :userId AND  \
+                grp_id    IS NOT NULL    \
+                todo_date = DATE(now())  \
+            `, {userId})
+            .execute();
+        
+        // 3. 이전 6일의 출결 삽입, 유저 로그인 정보 세팅
+        let date = new Date();
+        let dateString;
+        for(let i = 0; i < 6; i++) {
+            date.setDate(date.getDate() -1);
+            dateString = this.toFormattedDate(date);
+
+            await atteRepo.insert({
+                user_id: userId,
+                atte_at: dateString,
+            });
+        }
+
+        
+        await userRepo.createQueryBuilder()
+        .update()
+        .set({
+            user_cash: 400,
+            last_login: `to_char(now() - interval '1 day', 'yyyyMMdd')`,
+            login_cnt : 6,
+            login_seq : 6,
+        })
+        .execute();
+        
+
+        // 4. 인벤토리와 룸의 구미호 펫을 중간여우로 변경
+        //    경험치를 진화 직전으로 세팅
+        const kitsune = 3;
+        const midFox  = 2;
+        const tree    = 100;
+        const rug     = 104;
+        const petExp  = 1995;
+
+        await inveRepo.update({
+            user_id: userId,
+            item_id: kitsune,
+            pet_exp: petExp,
+        }, {
+            item_id: midFox,
+        });
+
+        await roomRepo.update({
+            user_id: userId,
+            item_id: kitsune,
+        }, {
+            item_id: midFox,
+        });
+
+        // 5. 트리와 러그 룸에서 삭제
+        await roomRepo.createQueryBuilder()
+            .delete()
+            .where(`
+                user_id = :userId AND \
+                (
+                    item_id = :tree   OR  \
+                    item_id = :rug
+                )
+            `, {userId, tree, rug})
+            .execute();
+
+            
+        // 6. 트리는 인벤토리에서 삭제
+        await inveRepo.delete({
+            user_id: userId,
+            item_id: tree,
+        })
+    }
+
+    private toFormattedDate(val: Date) {
+        const year = val.getFullYear() % 100;
+        const month = (val.getMonth() + 1).toString().padStart(2, '0');
+        const date = val.getDate().toString().padStart(2, '0');
+
+        return `${year}${month}${date}`;
+    }
+}

--- a/src/features/user/user.controller.ts
+++ b/src/features/user/user.controller.ts
@@ -21,13 +21,20 @@ import { GetUsersByContactsDto } from './dto/get-users-by-contacts.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { MulterConfig } from 'src/utils/MulterConfigService';
 import { AuthGuard } from '@nestjs/passport';
+import { Demo } from './demo';
 
 @Controller('user')
 export class UserController {
   constructor(
     private readonly usersService: UserService,
     private readonly multerConifg: MulterConfig,
+    private readonly demo: Demo,
   ) {}
+
+  @Post('/:user_id/demo')
+  async doDemo(@Param('user_id', ParseIntPipe) userId: number) {
+    return this.demo.run(userId);
+  }
 
   @Get('/')
   @UseGuards(AuthGuard('jwt'))

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -9,6 +9,7 @@ import { MulterConfig } from 'src/utils/MulterConfigService';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
+import { Demo } from './demo';
 
 @Module({
   imports: [
@@ -24,7 +25,7 @@ import { PassportModule } from '@nestjs/passport';
     , UtilsModule
   ],
   controllers: [UserController],
-  providers: [UserService, DoWithExceptions, MulterConfig],
+  providers: [UserService, DoWithExceptions, MulterConfig, Demo],
   exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
`{{base_url}}/user/{{user_id}}/demo`

feat: demo script draft

1. 출결 모두 삭제, 로그인 업적 삭제
2. 오늘자 그룹/개인투두 모두 삭제
3. 이전 6일의 출결 삽입
4. 유저 로그인 카운트 6, 캐시 400으로 업데이트
5. 데모용 개인투두 3개 삽입
6. 인벤토리와 룸의 구미호 펫을 중간여우로 변경, 경험치를 진화 직전으로 세팅
7. 트리와 러그 룸에서 삭제, 트리는 인벤토리에서 삭제

---
시연때 클릭한 데모 그룹 만드는 부분은 빠져 있습니다.

그룹 투두 사진 처리는 둘 중 하나로 가면 좋을 것 같습니다.
1. 시연날마다 그룹에 가입한 더미 유저들 투두 생성하고 이미지 업로드
8. 그룹투두 사진 보여줄때 3일간의 사진 보여주기

